### PR TITLE
Format with start_time-end_time

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,8 @@ each section. It then creates two new files:
 
 ```bash
 $ ruby timing.rb sample.md
+# or add your start time
+$ ruby timing.rb sample.md 9:00
 ```
 
 ### Input
@@ -18,6 +20,14 @@ This script expects your lesson plan to include headers formatted like so:
 ```markdown
 ## Intro (10 minutes)
 ```
+
+The parsing is quite forgiving.  You really just need a number to follow the open paren.
+```markdown
+## Intro (10 min)
+## Intro (10 m)
+## Intro (10)
+```
+
 
 The headers can be any level header.
 
@@ -75,4 +85,17 @@ lobortis eu, suscipit sed justo.
 
 Donec dolor justo, facilisis sit amet mattis a, fringilla quis velit. Nullam
 placerat erat sed tempus aliquam. Integer et efficitur neque.
+```
+
+If you pass a start time, the output will look like this:
+
+```
+$ ruby timing.rb sample.md 10:00
+```
+
+`sample_summary.md:`
+```markdown
+## Intro (5 minutes - 10:05)
+## Difficult Material (70 minutes - 11:15)
+## Closing (10 minutes - 11:25)
 ```

--- a/sample.md
+++ b/sample.md
@@ -6,11 +6,19 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vel pellentesque
 ipsum. Nullam sodales nec diam et placerat. Fusce egestas augue ut elit
 tincidunt, a dignissim mauris sagittis.
 
-## Difficult Material (70 minutes)
+## Difficult Material (85 min)
 
 Etiam est mauris, tempus vel arcu eu, dictum elementum nisl. Morbi a mi ante.
 Pellentesque eu cursus sem, eu convallis augue. Morbi erat nisl, cursus eu
 lobortis eu, suscipit sed justo.
+
+## Lunch (60)
+
+## More Difficult Material (30 min)
+
+convenevole cosa e carissime donne che ciascheduna cosa la quale l'uomo fa
+dallo ammirabile e santo nome di colui il quale di tutte fu facitore le dea
+principio per che dovendo io al vostro novellare sí come primo dare
 
 ## Closing (10 minutes)
 

--- a/sample_summary.md
+++ b/sample_summary.md
@@ -1,3 +1,5 @@
-## Intro (5 minutes - 00:05)
-## Difficult Material (70 minutes - 01:15)
-## Closing (10 minutes - 01:25)
+## Intro (5 minutes; 00:00-00:05)
+## Difficult Material (85 min; 00:05-01:30)
+## Lunch (60; 01:30-02:30)
+## More Difficult Material (30 min; 02:30-03:00)
+## Closing (10 minutes; 03:00-03:10)

--- a/sample_timed.md
+++ b/sample_timed.md
@@ -1,18 +1,26 @@
 # Sample Lesson
 
-## Intro (5 minutes - 00:05)
+## Intro (5 minutes; 00:00-00:05)
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vel pellentesque
 ipsum. Nullam sodales nec diam et placerat. Fusce egestas augue ut elit
 tincidunt, a dignissim mauris sagittis.
 
-## Difficult Material (70 minutes - 01:15)
+## Difficult Material (85 min; 00:05-01:30)
 
 Etiam est mauris, tempus vel arcu eu, dictum elementum nisl. Morbi a mi ante.
 Pellentesque eu cursus sem, eu convallis augue. Morbi erat nisl, cursus eu
 lobortis eu, suscipit sed justo.
 
-## Closing (10 minutes - 01:25)
+## Lunch (60; 01:30-02:30)
+
+## More Difficult Material (30 min; 02:30-03:00)
+
+convenevole cosa e carissime donne che ciascheduna cosa la quale l'uomo fa
+dallo ammirabile e santo nome di colui il quale di tutte fu facitore le dea
+principio per che dovendo io al vostro novellare sí come primo dare
+
+## Closing (10 minutes; 03:00-03:10)
 
 Donec dolor justo, facilisis sit amet mattis a, fringilla quis velit. Nullam
 placerat erat sed tempus aliquam. Integer et efficitur neque.

--- a/timing.rb
+++ b/timing.rb
@@ -1,22 +1,22 @@
-FILE_PATH = ARGV[0]
+require 'time' # for Time.parse
 
-def convert_to_hours_and_minutes(num_minutes)
-  minutes = num_minutes % 60
-  hours = (num_minutes / 60)
-  format("%02d:%02d", hours, minutes)
-end
+FILE_PATH = ARGV[0]
 
 new_file = []
 summary = []
-total_time = 0
+
+# always uses start_time, if none passed start_time is midnight.
+start_time = ARGV[1] ? Time.parse(ARGV[1]) : Time.parse('00:00')
+elapsed_time = start_time
 
 File.open(FILE_PATH, 'r') do |file|
   file.each do |line|
     match = line.match /(^\#+.*\()(\d+)(.*)(\))/
 
     if match
-      total_time += match[2].to_i
-      updated_header = match[1] + match[2] + match[3] + " - #{convert_to_hours_and_minutes(total_time)}" + match[4]
+      portion_minutes = match[2].to_i
+      elapsed_time += (portion_minutes * 60)
+      updated_header = match[1] + match[2] + match[3] + " - #{elapsed_time.strftime "%H:%M"}" + match[4]
 
       new_file << updated_header
       summary << updated_header
@@ -26,11 +26,12 @@ File.open(FILE_PATH, 'r') do |file|
 
   end
 end
+file_basename = File.basename(FILE_PATH, '.*')
 
-File.open("#{FILE_PATH[0...-3]}_timed.md", "w") do |file|
+File.open("#{file_basename}_timed.md", "w") do |file|
   file.puts new_file
 end
 
-File.open("#{FILE_PATH[0...-3]}_summary.md", "w") do |file|
+File.open("#{file_basename}_summary.md", "w") do |file|
   file.puts summary
 end

--- a/timing.rb
+++ b/timing.rb
@@ -15,8 +15,10 @@ File.open(FILE_PATH, 'r') do |file|
 
     if match
       portion_minutes = match[2].to_i
+      portion_start = elapsed_time
       elapsed_time += (portion_minutes * 60)
-      updated_header = match[1] + match[2] + match[3] + " - #{elapsed_time.strftime "%H:%M"}" + match[4]
+      portion_end = elapsed_time
+      updated_header = match[1] + match[2] + match[3] + "; #{portion_start.strftime("%H:%M")}-#{portion_end.strftime("%H:%M")}" + match[4]
 
       new_file << updated_header
       summary << updated_header

--- a/timing.rb
+++ b/timing.rb
@@ -9,23 +9,20 @@ summary = []
 start_time = ARGV[1] ? Time.parse(ARGV[1]) : Time.parse('00:00')
 elapsed_time = start_time
 
-File.open(FILE_PATH, 'r') do |file|
-  file.each do |line|
-    match = line.match /(^\#+.*\()(\d+)(.*)(\))/
+File.readlines(FILE_PATH).each do |line|
+  match = line.match /(^\#+.*\()(\d+)(.*)(\))/
 
-    if match
-      portion_minutes = match[2].to_i
-      portion_start = elapsed_time
-      elapsed_time += (portion_minutes * 60)
-      portion_end = elapsed_time
-      updated_header = match[1] + match[2] + match[3] + "; #{portion_start.strftime("%H:%M")}-#{portion_end.strftime("%H:%M")}" + match[4]
+  if match
+    portion_minutes = match[2].to_i
+    portion_start = elapsed_time
+    elapsed_time += (portion_minutes * 60)
+    portion_end = elapsed_time
+    updated_header = match[1] + match[2] + match[3] + "; #{portion_start.strftime("%H:%M")}-#{portion_end.strftime("%H:%M")}" + match[4]
 
-      new_file << updated_header
-      summary << updated_header
-    else
-      new_file << line
-    end
-
+    new_file << updated_header
+    summary << updated_header
+  else
+    new_file << line
   end
 end
 file_basename = File.basename(FILE_PATH, '.*')


### PR DESCRIPTION
I wanted to see start_time.  You had displayed end_time.  por que no las dos?

Note: I/you can revert c1a755457a089ceb55ccb1004272b7dc826aeb69 to remove the start_time.

```
$ cat sample_summary.md 
```

``` markdown
## Intro (5 minutes; 10:00-10:05)
## Difficult Material (85 min; 10:05-11:30)
## Lunch (60; 11:30-12:30)
## More Difficult Material (30 min; 12:30-13:00)
## Closing (10 minutes; 13:00-13:10)
```
